### PR TITLE
lazy load messages more smoothly.

### DIFF
--- a/src/main/kotlin/uk/co/rafearnold/calendar/Http.kt
+++ b/src/main/kotlin/uk/co/rafearnold/calendar/Http.kt
@@ -298,12 +298,12 @@ fun previousDaysRoute(
         val from = previousDaysFromQuery(request) ?: clock.toDate()
         val previousDays =
             daysRepo.getOpenedDaysDescFrom(impersonatedUser(request) ?: user(request), from = from, limit = 10)
-        val nextPreviousDaysLink = previousDaysLink(from = previousDays.lastOrNull()?.minusDays(1))
+        val nextPreviousDaysLink =
+            if (previousDays.isNotEmpty()) previousDaysLink(from = previousDays.last().minusDays(1)) else null
         val previousDaysBaseModel =
             object : PreviousDaysBaseModel {
                 override val previousDays: List<PreviousDayModel> = previousDays.toPreviousDayModels(messageLoader)
-                override val nextPreviousDaysLink: String = nextPreviousDaysLink
-                override val includeNextPreviousDaysLinkOnDay: Int = 9
+                override val nextPreviousDaysLink: String? = nextPreviousDaysLink
             }
         Response(OK).with(view of PreviousDaysViewModel(previousDaysBaseModel))
     }
@@ -325,7 +325,8 @@ class CalendarModelHelper(
         val today = clock.toDate()
         val openedDays = daysRepo.getOpenedDaysOfMonth(user, month)
         val previousDays = daysRepo.getOpenedDaysDescFrom(user, from = today, limit = 20)
-        val nextPreviousDaysLink = previousDaysLink(from = previousDays.lastOrNull()?.minusDays(1))
+        val nextPreviousDaysLink =
+            if (previousDays.isNotEmpty()) previousDaysLink(from = previousDays.last().minusDays(1)) else null
         val dayStates =
             (1..month.lengthOfMonth()).map {
                 val atDay = month.atDay(it)
@@ -359,8 +360,7 @@ private fun daysLink(month: YearMonth) = "/days?month=" + monthFormatter.format(
 
 private fun monthImageLink(month: YearMonth) = "/assets/month-images/${monthFormatter.format(month)}.jpg"
 
-private fun previousDaysLink(from: LocalDate?) =
-    "/previous-days" + if (from != null) "?from=" + from.format(DateTimeFormatter.ISO_LOCAL_DATE) else ""
+private fun previousDaysLink(from: LocalDate) = "/previous-days?from=" + from.format(DateTimeFormatter.ISO_LOCAL_DATE)
 
 fun adminUserFilter(
     adminEmails: List<String>,

--- a/src/main/kotlin/uk/co/rafearnold/calendar/Templating.kt
+++ b/src/main/kotlin/uk/co/rafearnold/calendar/Templating.kt
@@ -14,7 +14,7 @@ import java.time.format.DateTimeFormatter
 fun YearMonth.toCalendarModel(
     dayStates: List<DayState>,
     previousDays: List<PreviousDayModel>,
-    nextPreviousDaysLink: String,
+    nextPreviousDaysLink: String?,
     today: LocalDate,
     showClickMeTooltip: Boolean,
 ): CalendarBaseModel {
@@ -35,8 +35,7 @@ fun YearMonth.toCalendarModel(
         override val previousMonthDays: List<Int> = previousMonthDays()
         override val nextMonthDays: List<Int> = nextMonthDays()
         override val previousDays: List<PreviousDayModel> = previousDays
-        override val nextPreviousDaysLink: String = nextPreviousDaysLink
-        override val includeNextPreviousDaysLinkOnDay: Int = 19
+        override val nextPreviousDaysLink: String? = nextPreviousDaysLink
     }
 }
 
@@ -110,8 +109,7 @@ interface CalendarBaseModel : PreviousDaysBaseModel {
 
 interface PreviousDaysBaseModel {
     val previousDays: List<PreviousDayModel>
-    val nextPreviousDaysLink: String
-    val includeNextPreviousDaysLinkOnDay: Int
+    val nextPreviousDaysLink: String?
 }
 
 data class DayModel(

--- a/src/main/resources/previous-days.html
+++ b/src/main/resources/previous-days.html
@@ -1,11 +1,14 @@
+{% if model.nextPreviousDaysLink %}
+<div hx-get="{{ model.nextPreviousDaysLink }}" hx-target="#previous-days" hx-swap="beforeend" hx-trigger="revealed">
+{% endif %}
 {% for previousDay in model.previousDays %}
 <div class="mt-4 w-full aspect-7/5 flex bg-day-{{ previousDay.colorIndex }} border-2 border-black dark:border-white dark:text-white rounded-2xl shadow-2xl">
-    {% if loop.index == model.includeNextPreviousDaysLinkOnDay %}
-    <div hx-get="{{ model.nextPreviousDaysLink }}" hx-target="#previous-days" hx-swap="beforeend" hx-trigger="revealed"></div>
-    {% endif %}
     <div class="relative flex grow items-center justify-center text-center">
         <div data-testid="previous-day-date" class="absolute text-sm left-5 top-3">{{ previousDay.date }}</div>
         <div data-testid="previous-day-text" class="p-6 pt-10 sm:p-12 whitespace-pre-wrap max-[400px]:text-sm">{{ previousDay.text | raw }}</div>
     </div>
 </div>
 {% endfor %}
+{% if model.nextPreviousDaysLink %}
+</div>
+{% endif %}

--- a/src/test/kotlin/uk/co/rafearnold/calendar/EndToEndTests.kt
+++ b/src/test/kotlin/uk/co/rafearnold/calendar/EndToEndTests.kt
@@ -627,16 +627,15 @@ class EndToEndTests {
 
         val page = browser.newPage()
         page.navigateHome(port = server.port())
-        val previousDays = openedDays.take(20).map { it.toPreviousDay() }.toMutableList()
-        assertEquals(20, previousDays.size)
+        page.previousDayTexts().nth(1).scrollIntoViewIfNeeded()
+        val previousDays = openedDays.take(30).map { it.toPreviousDay() }.toMutableList()
         page.assertPreviousDaysAre(previousDays)
 
-        page.previousDayTexts().nth(19).scrollIntoViewIfNeeded()
-        previousDays.addAll(openedDays.subList(20, 30).map { it.toPreviousDay() })
-        page.assertPreviousDaysAre(previousDays)
-
-        page.previousDayTexts().nth(29).scrollIntoViewIfNeeded()
+        page.previousDayTexts().nth(25).scrollIntoViewIfNeeded()
         previousDays.addAll(openedDays.subList(30, 37).map { it.toPreviousDay() })
+        page.assertPreviousDaysAre(previousDays)
+
+        page.previousDayTexts().nth(36).scrollIntoViewIfNeeded()
         page.assertPreviousDaysAre(previousDays)
     }
 
@@ -823,11 +822,9 @@ class EndToEndTests {
                 openedDays.forEach { daysRepository.markDayAsOpened(otherUser, it) }
             }
 
-            var expectedPreviousDays = openedDays.take(20).map { it.toPreviousDay() }.toMutableList()
+            var expectedPreviousDays = openedDays.take(30).map { it.toPreviousDay() }.toMutableList()
             otherUserPage.reload()
-            otherUserPage.assertPreviousDaysAre(expectedPreviousDays)
-            otherUserPage.previousDayTexts().nth(19).scrollIntoViewIfNeeded()
-            expectedPreviousDays.addAll(openedDays.subList(20, 30).map { it.toPreviousDay() })
+            otherUserPage.previousDayTexts().nth(1).scrollIntoViewIfNeeded()
             otherUserPage.assertPreviousDaysAre(expectedPreviousDays)
 
             val impersonatorPage = browser.newPage()
@@ -835,10 +832,8 @@ class EndToEndTests {
             impersonatorPage.assertPreviousDaysAre(emptyList())
 
             impersonatorPage.impersonate(emailToImpersonate = otherUserEmail)
-            expectedPreviousDays = openedDays.take(20).map { it.toPreviousDay() }.toMutableList()
-            impersonatorPage.assertPreviousDaysAre(expectedPreviousDays)
-            impersonatorPage.previousDayTexts().nth(19).scrollIntoViewIfNeeded()
-            expectedPreviousDays.addAll(openedDays.subList(20, 30).map { it.toPreviousDay() })
+            expectedPreviousDays = openedDays.take(30).map { it.toPreviousDay() }.toMutableList()
+            otherUserPage.previousDayTexts().nth(1).scrollIntoViewIfNeeded()
             impersonatorPage.assertPreviousDaysAre(expectedPreviousDays)
         }
     }


### PR DESCRIPTION
now will load the next set of messages as soon as the previous set is revealed, rather than after scrolling to the bottom of the previous set.